### PR TITLE
Fixed vault healthcheck outputting too much log

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -6,15 +6,22 @@ import (
 	"github.com/quan-to/chevron"
 	"github.com/quan-to/chevron/agent"
 	"github.com/quan-to/chevron/etc"
+	"github.com/quan-to/chevron/vaultManager"
 	"github.com/quan-to/slog"
 	"net/http"
 )
 
 func GenRemoteSignerServerMux(slog slog.Instance, sm etc.SMInterface, gpg etc.PGPInterface) *mux.Router {
+	var vm *vaultManager.VaultManager
 	log := slog.Scope("MUX")
+
+	if remote_signer.VaultStorage {
+		vm = vaultManager.MakeVaultManager(log, remote_signer.KeyPrefix)
+	}
+
 	ge := MakeGPGEndpoint(log, sm, gpg)
 	ie := MakeInternalEndpoint(log, sm, gpg)
-	te := MakeTestsEndpoint(log)
+	te := MakeTestsEndpoint(log, vm)
 	kre := MakeKeyRingEndpoint(log, sm, gpg)
 	sks := MakeSKSEndpoint(log, sm, gpg)
 	tm := agent.MakeTokenManager(log)

--- a/server/tests.go
+++ b/server/tests.go
@@ -47,7 +47,7 @@ func (ge *TestsEndpoint) checkExternal() bool {
 		}
 	}
 
-	if remote_signer.VaultStorage {
+	if ge.vm != nil {
 		health, err := ge.vm.HealthStatus()
 
 		if err != nil {

--- a/server/tests.go
+++ b/server/tests.go
@@ -13,10 +13,11 @@ import (
 
 type TestsEndpoint struct {
 	log slog.Instance
+	vm *vaultManager.VaultManager
 }
 
 // MakeTestsEndpoint creates an instance of healthcheck tests endpoint
-func MakeTestsEndpoint(log slog.Instance) *TestsEndpoint {
+func MakeTestsEndpoint(log slog.Instance, vm *vaultManager.VaultManager) *TestsEndpoint {
 	if log == nil {
 		log = slog.Scope("Tests")
 	} else {
@@ -25,6 +26,7 @@ func MakeTestsEndpoint(log slog.Instance) *TestsEndpoint {
 
 	return &TestsEndpoint{
 		log: log,
+		vm: vm,
 	}
 }
 
@@ -46,17 +48,16 @@ func (ge *TestsEndpoint) checkExternal() bool {
 	}
 
 	if remote_signer.VaultStorage {
-		vm := vaultManager.MakeVaultManager(ge.log, remote_signer.KeyPrefix)
-		health, err := vm.HealthStatus()
+		health, err := ge.vm.HealthStatus()
 
 		if err != nil {
 			ge.log.Error(err)
-			isHealthy = false
+			return false
 		}
 
-		if !health.Initialized || health.Sealed {
+		if health != nil && !health.Initialized || health.Sealed {
 			ge.log.Info("Vault initialized? %t, is sealed? %t", health.Initialized, health.Sealed)
-			isHealthy = false
+			return false
 		}
 	}
 


### PR DESCRIPTION
Fixed vault healthcheck outputting too much log due an VaultManager instance being created every time.