### PR TITLE
[FEAT] ChevronLib Quanto Sign/Verify Calls + ChangeKeyPassword

### DIFF
--- a/chevronlib/keyManipulation.go
+++ b/chevronlib/keyManipulation.go
@@ -46,8 +46,9 @@ func ChangeKeyPassword(keyData, currentPassword, newPassword string) (newKeyData
 	if err != nil {
 		return
 	}
+	newKeyData, err = pgpBackend.GetPrivateKeyAsciiReencrypt(ctx, fp, currentPassword, newPassword)
 
-	newKeyData, err = pgpBackend.GetPrivateKeyAscii(ctx, fp, newPassword)
+	_ = pgpBackend.DeleteKey(ctx, fp) // Clean key after changing password
 	return
 }
 

--- a/chevronlib/signature.go
+++ b/chevronlib/signature.go
@@ -88,7 +88,7 @@ func SignBase64Data(b64data, fingerprint string) (result string, err error) {
 	return SignData(data, fingerprint)
 }
 
-// QuantoSignData signs the data using a already loaded and unlocked private key and returning in Quanto Signature format.
+// QuantoSignBase64Data signs the data using a already loaded and unlocked private key and returning in Quanto Signature format.
 //  The b64data is a raw binary data encoded in base64 string
 func QuantoSignBase64Data(b64data, fingerprint string) (result string, err error) {
 	var data []byte

--- a/chevronlib/signature.go
+++ b/chevronlib/signature.go
@@ -3,6 +3,7 @@ package chevronlib
 import (
 	"crypto"
 	"encoding/base64"
+	remote_signer "github.com/quan-to/chevron"
 )
 
 // LoadKey loads a private or public key into the memory keyring
@@ -24,6 +25,27 @@ func VerifySignature(data []byte, signature string) (result bool, err error) {
 	return pgpBackend.VerifySignature(ctx, data, signature)
 }
 
+// QuantoVerifySignature verifies a signature in Quanto Signature Format using a already loaded public key
+// export VerifySignature
+func QuantoVerifySignature(data []byte, signature string) (result bool, err error) {
+	signature = remote_signer.Quanto2GPG(signature)
+
+	return pgpBackend.VerifySignature(ctx, data, signature)
+}
+
+// QuantoVerifyBase64DataSignature verifies a signature using a already loaded public key.
+// The b64data is a raw binary data encoded in base64 string
+// export VerifyBase64DataSignature
+func QuantoVerifyBase64DataSignature(b64data, signature string) (result bool, err error) {
+	var data []byte
+	data, err = base64.StdEncoding.DecodeString(b64data)
+	if err != nil {
+		return
+	}
+
+	return QuantoVerifySignature(data, signature)
+}
+
 // VerifyBase64DataSignature verifies a signature using a already loaded public key. The b64data is a raw binary data encoded in base64 string
 // export VerifyBase64DataSignature
 func VerifyBase64DataSignature(b64data, signature string) (result bool, err error) {
@@ -42,7 +64,19 @@ func SignData(data []byte, fingerprint string) (result string, err error) {
 	return pgpBackend.SignData(ctx, fingerprint, data, crypto.SHA512)
 }
 
-// SignBase64Data signs data using a already loaded and unlocked private key. The b64data is a raw binary data encoded in base64 string
+// QuantoSignData signs the data using a already loaded and unlocked private key and returning in Quanto PGP Signature format
+func QuantoSignData(data []byte, fingerprint string) (result string, err error) {
+	result, err = pgpBackend.SignData(ctx, fingerprint, data, crypto.SHA512)
+	if err != nil {
+		return "", err
+	}
+	result = remote_signer.GPG2Quanto(result, fingerprint, "SHA512")
+
+	return result, nil
+}
+
+// SignBase64Data signs data using a already loaded and unlocked private key.
+// The b64data is a raw binary data encoded in base64 string
 // export SignBase64Data
 func SignBase64Data(b64data, fingerprint string) (result string, err error) {
 	var data []byte
@@ -52,4 +86,16 @@ func SignBase64Data(b64data, fingerprint string) (result string, err error) {
 	}
 
 	return SignData(data, fingerprint)
+}
+
+// QuantoSignData signs the data using a already loaded and unlocked private key and returning in Quanto Signature format.
+//  The b64data is a raw binary data encoded in base64 string
+func QuantoSignBase64Data(b64data, fingerprint string) (result string, err error) {
+	var data []byte
+	data, err = base64.StdEncoding.DecodeString(b64data)
+	if err != nil {
+		return
+	}
+
+	return QuantoSignData(data, fingerprint)
 }

--- a/chevronlib/signature_test.go
+++ b/chevronlib/signature_test.go
@@ -1,0 +1,340 @@
+package chevronlib
+
+import (
+	"encoding/base64"
+	remote_signer "github.com/quan-to/chevron"
+	"github.com/quan-to/chevron/keymagic"
+	"testing"
+)
+
+func TestGenerateKey(t *testing.T) {
+	// Test Generate Key < MinBits
+	_, err := GenerateKey(testKeyPassword, "", keymagic.MinKeyBits-1)
+	if err == nil {
+		t.Errorf("Expected GenerateKey with bits < %d to fail", keymagic.MinKeyBits)
+	}
+
+	// Test Generate Key = MinKeyBits
+	result, err := GenerateKey(testKeyPassword, "", keymagic.MinKeyBits)
+	if err != nil {
+		t.Errorf("Expected GenerateKey with bits = %d to generate a key. Got %q", keymagic.MinKeyBits, err)
+	}
+
+	if len(result) == 0 {
+		t.Error("Expected a generated key, got empty")
+	}
+}
+
+func TestLoadKey(t *testing.T) {
+	l, err := LoadKey(testKey)
+	if err != nil {
+		t.Errorf("Expected key to be loaded. But got %q", err)
+	}
+
+	if l == 0 {
+		t.Error("Expected one private key to be loaded but got 0")
+	}
+
+	_, err = LoadKey("huebr")
+	if err == nil {
+		t.Error("Expected \"huebr\" to trigger a key load error but got none")
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	_, _ = LoadKey(testKey)
+
+	res, err := VerifySignature([]byte(payloadToSign), testSignature)
+
+	if err != nil {
+		t.Errorf("Expected signature to be valid but got %q", err)
+	}
+
+	if !res {
+		t.Error("Expected signature go be valid but got false")
+	}
+
+	res, err = VerifySignature([]byte(payloadToSign+"BLA"), testSignature)
+
+	if err == nil {
+		t.Errorf("Expected signature to have an error but got nil")
+	}
+
+	if res {
+		t.Error("Expected signature go be invalid but got true")
+	}
+}
+
+func TestVerifyBase64DataSignature(t *testing.T) {
+	_, _ = LoadKey(testKey)
+
+	res, err := VerifyBase64DataSignature(base64.StdEncoding.EncodeToString([]byte(payloadToSign)), testSignature)
+
+	if err != nil {
+		t.Errorf("Expected signature to be valid but got %q", err)
+	}
+
+	if !res {
+		t.Error("Expected signature go be valid but got false")
+	}
+
+	res, err = VerifyBase64DataSignature(base64.StdEncoding.EncodeToString([]byte(payloadToSign+"BLA")), testSignature)
+
+	if err == nil {
+		t.Errorf("Expected signature to have an error but got nil")
+	}
+
+	if res {
+		t.Error("Expected signature go be invalid but got true")
+	}
+
+}
+
+func TestQuantoVerifySignature(t *testing.T) {
+	_, _ = LoadKey(testKey)
+
+	sig := remote_signer.GPG2Quanto(testSignature, testKeyFingerprint, "SHA512")
+
+	res, err := QuantoVerifySignature([]byte(payloadToSign), sig)
+
+	if err != nil {
+		t.Errorf("Expected signature to be valid but got %q", err)
+	}
+
+	if !res {
+		t.Error("Expected signature go be valid but got false")
+	}
+
+	res, err = QuantoVerifySignature([]byte(payloadToSign+"BLA"), sig)
+
+	if err == nil {
+		t.Errorf("Expected signature to have an error but got nil")
+	}
+
+	if res {
+		t.Error("Expected signature go be invalid but got true")
+	}
+}
+
+func TestQuantoVerifyBase64DataSignature(t *testing.T) {
+	_, _ = LoadKey(testKey)
+
+	sig := remote_signer.GPG2Quanto(testSignature, testKeyFingerprint, "SHA512")
+
+	res, err := QuantoVerifyBase64DataSignature(base64.StdEncoding.EncodeToString([]byte(payloadToSign)), sig)
+
+	if err != nil {
+		t.Errorf("Expected signature to be valid but got %q", err)
+	}
+
+	if !res {
+		t.Error("Expected signature go be valid but got false")
+	}
+
+	res, err = QuantoVerifyBase64DataSignature(base64.StdEncoding.EncodeToString([]byte(payloadToSign+"BLA")), sig)
+
+	if err == nil {
+		t.Errorf("Expected signature to have an error but got nil")
+	}
+
+	if res {
+		t.Error("Expected signature go be invalid but got true")
+	}
+}
+
+func TestUnlockKey(t *testing.T) {
+	_, _ = LoadKey(testKey)
+
+	err := UnlockKey(testKeyFingerprint, testKeyPassword)
+
+	if err != nil {
+		t.Errorf("Expected key to be unlocked but got %q instead", err)
+	}
+
+	err = UnlockKey(testKeyFingerprint, "ABCD1029371n2cy39812y381jx")
+
+	if err == nil {
+		t.Errorf("Expected key unlock to return error but got nil")
+	}
+}
+
+func TestSignData(t *testing.T) {
+	_, _ = LoadKey(testKey)
+	_ = UnlockKey(testKeyFingerprint, testKeyPassword)
+
+	result, err := SignData([]byte(payloadToSign), testKeyFingerprint)
+
+	if err != nil {
+		t.Errorf("Expected signature to work but got %q", err)
+	}
+
+	valid, err := VerifySignature([]byte(payloadToSign), result)
+
+	if err != nil {
+		t.Errorf("Error validating signature: %q", err)
+	}
+
+	if !valid {
+		t.Error("Expected signature to be valid, but got false")
+	}
+}
+
+func TestSignBase64Data(t *testing.T) {
+	_, _ = LoadKey(testKey)
+	_ = UnlockKey(testKeyFingerprint, testKeyPassword)
+
+	result, err := SignBase64Data(base64.StdEncoding.EncodeToString([]byte(payloadToSign)), testKeyFingerprint)
+
+	if err != nil {
+		t.Errorf("Expected signature to work but got %q", err)
+	}
+
+	valid, err := VerifySignature([]byte(payloadToSign), result)
+
+	if err != nil {
+		t.Errorf("Error validating signature: %q", err)
+	}
+
+	if !valid {
+		t.Error("Expected signature to be valid, but got false")
+	}
+}
+
+func TestQuantoSignData(t *testing.T) {
+	_, _ = LoadKey(testKey)
+	_ = UnlockKey(testKeyFingerprint, testKeyPassword)
+
+	result, err := QuantoSignData([]byte(payloadToSign), testKeyFingerprint)
+
+	if err != nil {
+		t.Errorf("Expected signature to work but got %q", err)
+	}
+
+	valid, err := QuantoVerifySignature([]byte(payloadToSign), result)
+
+	if err != nil {
+		t.Errorf("Error validating signature: %q", err)
+	}
+
+	if !valid {
+		t.Error("Expected signature to be valid, but got false")
+	}
+}
+
+func TestQuantoSignBase64Data(t *testing.T) {
+	_, _ = LoadKey(testKey)
+	_ = UnlockKey(testKeyFingerprint, testKeyPassword)
+
+	result, err := QuantoSignBase64Data(base64.StdEncoding.EncodeToString([]byte(payloadToSign)), testKeyFingerprint)
+
+	if err != nil {
+		t.Errorf("Expected signature to work but got %q", err)
+	}
+
+	valid, err := QuantoVerifySignature([]byte(payloadToSign), result)
+
+	if err != nil {
+		t.Errorf("Error validating signature: %q", err)
+	}
+
+	if !valid {
+		t.Error("Expected signature to be valid, but got false")
+	}
+}
+
+func TestGetPublicKey(t *testing.T) {
+	_, _ = LoadKey(testKey)
+	pubKey, err := GetPublicKey(testKeyFingerprint)
+
+	if err != nil {
+		t.Errorf("Expected public key but got error %q", err)
+	}
+
+	fps, err := GetKeyFingerprints(pubKey)
+
+	if err != nil {
+		t.Errorf("Expected public key to be valid got error %q", err)
+	}
+
+	if len(fps) == 0 {
+		t.Errorf("Got no fingerprints, expected one")
+	} else if fps[0] != testKeyFingerprint {
+		t.Errorf("Expected fingerprint to be %s but got %s", testKeyFingerprint, fps[0])
+	}
+}
+
+const payloadToSign = "HUEBR"
+
+const testSignature = `-----BEGIN PGP SIGNATURE-----
+
+wsBcBAABCgAQBQJedt7dCRDORQOylH4iAgAArvYIAMY9G3oQA0ZL7CwZmhjRfu6d
+BfNst48oHJ3mSLe1oTATkkiRvJBgXaNg9aFP0rNa5Cx8Hlkhjqp0QYRmPNhKjWhD
+L+LpxLasESQeWLVZnDkaz75YHw6UK6TRIsAH7Py/zgiGlNehWx3+0rjkBxEEjJgK
+aM5wBDoPi4+1yAf1ZSanypb2fq3Mzy77HKtew+9BCKhC8DE9uXN6PGC4Q/LhgDON
+aXS7WqLoIaB9RjvTDHbR4V8rP5pEx5s/GhJHgYAYzcJvhxog3n03GAIW3DiQdbih
+h72Ll0XnpYkiiSvwz7UtfeveDSNFUSfeoOKdGsM/8rrZIexHWSJVdUc0I53ITQY=
+=K6nc
+-----END PGP SIGNATURE-----`
+
+const testKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+Version: GnuPG v2
+Comment: Generated by Chevron
+
+xcL0BF52btoBCADtWsLWwS0AugQ98LnVnndA8WPafCkfUWtikBr1CyjXeDP4rqOz
+2ovhancM1XDo025AMesfQCB38GFSWEaDJcFG5R1fnRdVqsl0G/+yaSWuEmqP6C7a
+Jux//xUpe7jMc8O341SQ1P+FEJv7J8nHi8hXbweuS/mxn7Yiu3rmKzXTKBPJitkF
+k/kU/TQcxuoN5LGrU87DEFYFNr1FQIR2q75/8yXhY6HsP6HQkoirVm8AEwo10+9O
+6qcW4vs3UnR2/hilxefTOVa3nnTIp/4fGs1xl994olHNYLmIXPm2B3HvJCIHeJUs
+yMIZCwMSpB4Q30RRO0LDXgpuQwrgd4WIThkLABEBAAH/BwMCaELZXGd6MaZg2ZUa
+NOMX1pSewCSu9/cQy4U0O5kCDc29SFeysi/zvEn/QfuprNd5GgqEVqKXF20HQg5M
+a17N4ibJAvw7QFuVAA8fElc2JchurAlfmE6qD0APt/Qo9Xf73P0nfdfvM77d6Xy2
++Pov/+i9O71SOQ72PfQzDy+TgVGAopVKFb3RkpeWivI0UmLnHiDh5ewpbDfbCB3t
+F1O4JvdWHsJVe/lIJeHi2GMvLxLFkdBq9fnrgLjSB7aZ09XDqcjJqQmgXwC7bQwR
+y4HKozBKAp/g4tgPM6S68ua+1K4s+aiKjjlgK3W+Yi8A0IBzPxYmlsovTn+CmlFo
+iB9f+yufuMkIe64D1cHyxIPa+XrdFrUWv94S61FYPJMkEOlEJQWfe8zAtv0by0wX
+26ouf4trG1qX7duYSGxRgzxCPIpmNU2JQaZZlR0NkXPPQfg9cc02SbePY2Lg0VG8
+OAYO14maYrQ4Wr7kxXSbWPm5rbIvjbvTqRzjEOSz47P5vypNpRHIMQifpzmMWz+C
+al4HaRKOh0qwUXvHh1cIhsBpKqUOr9mDV0Pa0MA+4OGGMXlhu5c63H+Pu+lt97Fc
+yHspLSexxm6M8PSjiDerUaXroqtoJWL9ynM49mIXjq0xerjIII814fDarRQqcyp5
+l0/0IgdASBuM2y9yh447WaB3t1WzsfgiqatyAjVw8IYyqxB/mWU6gedsD3AgtZqh
+2vn5xQkooi5p3tAPMbJrSWuIv07HAeNAfITyXkOHxf/Ym9eUn+ZTDxWOAHsX9ZAJ
+ic/s4QdL4Yd2iahtR61RwTIrQP/l5pprNftjaX3HWKZMjWxRfz7yUA8hGYhn6ivS
+4T0+9zMnVcCAdfgfj+8pjXJIfuVJ5bApIu7R3oRZjsE+8WN1gjGXzQtMdWNhcyBU
+ZXNrZcLAXwQTAQoAEwUCXnZu2gkQzkUDspR+IgICGw8AAN4cCAAq8QCLTz2xyg29
+VpxrpL8K+3p4RcqsG3PBOigXsOgi/UlCkiNceBwWpyANN2FicYbKpsU2yHKn5Hgh
+0BlcjhE9V/a8qzFftTnPTZeMDvBKBM9DAIBjdVbNdMDeZQ4XnckE+4wPNKiOA7pE
+F1mpuarrDIaxVWESn9BZxsTUBgx7LoLK/MKQX+oATAD96gmmou0K6M1lt2m0Vqva
+nTnwxSeghH3/w7eNXmfmpGAKec5TYVLrLFMPc34ELclONT3xuRx1BBs1HUpXs7so
+IeWPJX37xC5oFnuh9MnF0lf/M1hwbNrqC0sT7nUXLFX40zO350Sv2kJxasWoZGov
+dmwxVNpdxcL0BF52btoBCADtWsLWwS0AugQ98LnVnndA8WPafCkfUWtikBr1CyjX
+eDP4rqOz2ovhancM1XDo025AMesfQCB38GFSWEaDJcFG5R1fnRdVqsl0G/+yaSWu
+EmqP6C7aJux//xUpe7jMc8O341SQ1P+FEJv7J8nHi8hXbweuS/mxn7Yiu3rmKzXT
+KBPJitkFk/kU/TQcxuoN5LGrU87DEFYFNr1FQIR2q75/8yXhY6HsP6HQkoirVm8A
+Ewo10+9O6qcW4vs3UnR2/hilxefTOVa3nnTIp/4fGs1xl994olHNYLmIXPm2B3Hv
+JCIHeJUsyMIZCwMSpB4Q30RRO0LDXgpuQwrgd4WIThkLABEBAAH/BwMCaELZXGd6
+MaZg2ZUaNOMX1pSewCSu9/cQy4U0O5kCDc29SFeysi/zvEn/QfuprNd5GgqEVqKX
+F20HQg5Ma17N4ibJAvw7QFuVAA8fElc2JchurAlfmE6qD0APt/Qo9Xf73P0nfdfv
+M77d6Xy2+Pov/+i9O71SOQ72PfQzDy+TgVGAopVKFb3RkpeWivI0UmLnHiDh5ewp
+bDfbCB3tF1O4JvdWHsJVe/lIJeHi2GMvLxLFkdBq9fnrgLjSB7aZ09XDqcjJqQmg
+XwC7bQwRy4HKozBKAp/g4tgPM6S68ua+1K4s+aiKjjlgK3W+Yi8A0IBzPxYmlsov
+Tn+CmlFoiB9f+yufuMkIe64D1cHyxIPa+XrdFrUWv94S61FYPJMkEOlEJQWfe8zA
+tv0by0wX26ouf4trG1qX7duYSGxRgzxCPIpmNU2JQaZZlR0NkXPPQfg9cc02SbeP
+Y2Lg0VG8OAYO14maYrQ4Wr7kxXSbWPm5rbIvjbvTqRzjEOSz47P5vypNpRHIMQif
+pzmMWz+Cal4HaRKOh0qwUXvHh1cIhsBpKqUOr9mDV0Pa0MA+4OGGMXlhu5c63H+P
+u+lt97FcyHspLSexxm6M8PSjiDerUaXroqtoJWL9ynM49mIXjq0xerjIII814fDa
+rRQqcyp5l0/0IgdASBuM2y9yh447WaB3t1WzsfgiqatyAjVw8IYyqxB/mWU6geds
+D3AgtZqh2vn5xQkooi5p3tAPMbJrSWuIv07HAeNAfITyXkOHxf/Ym9eUn+ZTDxWO
+AHsX9ZAJic/s4QdL4Yd2iahtR61RwTIrQP/l5pprNftjaX3HWKZMjWxRfz7yUA8h
+GYhn6ivS4T0+9zMnVcCAdfgfj+8pjXJIfuVJ5bApIu7R3oRZjsE+8WN1gjGXwsBi
+BBgBCgAWBQJedm7aCRDORQOylH4iAgIbDwIVCgAACWMIAClFP9hMxTwPMl2L6QSr
+cuFO2ujheqgeMwna8wNp/LwUybtVEQ5aZ67K0knAb1s64q1IYkFbWMJIGEd5hA+B
+AHnqGT+7etcCYA24M3iJoKaBZPgdUkMGGndp8hgh7M/8aJmYal3jTNus+sLRWRFU
+sslFLkdwa0XtSFh2Wh+9dXqi55N9vRH05aBWEMtlr2qt1X0Y0G3VAySrXUfrG9Yv
+QD1eq2AWBXjYosjwDaUR2+v7kAN/euG1Bvs2Vd1/+mfSn2WwBmHhQHDhdWW0oGTp
+pq29HT8vVfshyd7NLjDGf4Acifgpv2uIOOKw8QTyi5fMsPr5EGFWgvUnj7WUZzMe
+bBM=
+=36ik
+-----END PGP PRIVATE KEY BLOCK-----`
+
+const testKeyPassword = `1234567890`
+const testKeyFingerprint = `CE4503B2947E2202`

--- a/chevronlib/signature_test.go
+++ b/chevronlib/signature_test.go
@@ -263,6 +263,27 @@ func TestGetPublicKey(t *testing.T) {
 	}
 }
 
+func TestChangeKeyPassword(t *testing.T) {
+	const tmpPass = "anei1he9m298em1xh"
+	key, _ := GenerateKey(tmpPass, "ACD123", 2048)
+
+	newKey, err := ChangeKeyPassword(key, tmpPass, testKeyPassword)
+
+	if err != nil {
+		t.Fatalf("Unexpected error changing key password %q", err)
+	}
+
+	fps, _ := GetKeyFingerprints(newKey)
+
+	_, _ = LoadKey(newKey)
+
+	err = UnlockKey(fps[0], testKeyPassword)
+
+	if err != nil {
+		t.Fatalf("Unexpected error when unlocking key with new password: %q", err)
+	}
+}
+
 const payloadToSign = "HUEBR"
 
 const testSignature = `-----BEGIN PGP SIGNATURE-----

--- a/cmd/lib/chevron.go
+++ b/cmd/lib/chevron.go
@@ -61,6 +61,30 @@ func VerifySignature(data *C.char, dataLen C.int, signature *C.char, result *C.c
 	return FALSE
 }
 
+// QuantoVerifySignature verifies a signature in Quanto Signature Format using a already loaded public key
+//export QuantoVerifySignature
+func QuantoVerifySignature(data *C.char, dataLen C.int, signature *C.char, result *C.char, resultLen C.int) C.int {
+	goData := make([]byte, int(dataLen))
+	copyFromCToGo(goData, data, int(dataLen))
+	goSignature := C.GoString(signature)
+
+	rLen := int(resultLen)
+
+	r, e := chevronlib.QuantoVerifySignature(goData, goSignature)
+
+	if e != nil { // Error
+		copyStringToC(result, []byte(e.Error()), rLen)
+		return ERROR
+	}
+
+	if r { // Signature Valid
+		return TRUE
+	}
+
+	// Signature Invalid
+	return FALSE
+}
+
 // VerifyBase64DataSignature verifies a signature using a already loaded public key. The b64data is a raw binary data encoded in base64 string
 //export VerifyBase64DataSignature
 func VerifyBase64DataSignature(b64data, signature *C.char, result *C.char, resultLen C.int) C.int {
@@ -68,6 +92,28 @@ func VerifyBase64DataSignature(b64data, signature *C.char, result *C.char, resul
 	goSignature := C.GoString(signature)
 	rLen := int(resultLen)
 	r, e := chevronlib.VerifyBase64DataSignature(goB64Data, goSignature)
+
+	if e != nil { // Error
+		copyStringToC(result, []byte(e.Error()), rLen)
+		return ERROR
+	}
+
+	if r { // Signature Valid
+		return TRUE
+	}
+
+	// Signature Invalid
+	return FALSE
+}
+
+// QuantoVerifyBase64DataSignature verifies a signature in Quanto Signature Format using a already loaded public key.
+// The b64data is a raw binary data encoded in base64 string
+//export QuantoVerifyBase64DataSignature
+func QuantoVerifyBase64DataSignature(b64data, signature *C.char, result *C.char, resultLen C.int) C.int {
+	goB64Data := C.GoString(b64data)
+	goSignature := C.GoString(signature)
+	rLen := int(resultLen)
+	r, e := chevronlib.QuantoVerifyBase64DataSignature(goB64Data, goSignature)
 
 	if e != nil { // Error
 		copyStringToC(result, []byte(e.Error()), rLen)
@@ -102,12 +148,53 @@ func SignData(data *C.char, dataLen C.int, fingerprint *C.char, result *C.char, 
 	return OK
 }
 
-// SignBase64Data signs data using a already loaded and unlocked private key. The b64data is a raw binary data encoded in base64 string
+// QuantoSignData signs data using a already loaded and unlocked private key and returns in Quanto Signature Format
+//export QuantoSignData
+func QuantoSignData(data *C.char, dataLen C.int, fingerprint *C.char, result *C.char, resultLen C.int) C.int {
+	goData := make([]byte, int(dataLen))
+	copyFromCToGo(goData, data, int(dataLen))
+	goFingerprint := C.GoString(fingerprint)
+
+	rLen := int(resultLen)
+
+	r, e := chevronlib.QuantoSignData(goData, goFingerprint)
+	if e != nil {
+		copyStringToC(result, []byte(e.Error()), rLen)
+		return ERROR
+	}
+
+	copyStringToC(result, []byte(r), rLen)
+
+	return OK
+}
+
+// SignBase64Data signs data using a already loaded and unlocked private key.
+// The b64data is a raw binary data encoded in base64 string
 //export SignBase64Data
 func SignBase64Data(b64data, fingerprint *C.char, result *C.char, resultLen C.int) C.int {
 	goB64Data := C.GoString(b64data)
 	goFingerprint := C.GoString(fingerprint)
 	r, e := chevronlib.SignBase64Data(goB64Data, goFingerprint)
+
+	rLen := int(resultLen)
+
+	if e != nil {
+		copyStringToC(result, []byte(e.Error()), rLen)
+		return ERROR
+	}
+
+	copyStringToC(result, []byte(r), rLen)
+
+	return OK
+}
+
+// SignBase64Data signs data using a already loaded and unlocked private key. Returns in Quanto Signature Format
+// The b64data is a raw binary data encoded in base64 string
+//export QuantoSignBase64Data
+func QuantoSignBase64Data(b64data, fingerprint *C.char, result *C.char, resultLen C.int) C.int {
+	goB64Data := C.GoString(b64data)
+	goFingerprint := C.GoString(fingerprint)
+	r, e := chevronlib.QuantoSignBase64Data(goB64Data, goFingerprint)
 
 	rLen := int(resultLen)
 

--- a/cmd/lib/wraps/nodejs/native/asyncworkers.h
+++ b/cmd/lib/wraps/nodejs/native/asyncworkers.h
@@ -11,5 +11,7 @@ Napi::Value UnlockKeyAsync(const Napi::CallbackInfo& info);
 Napi::Value VerifySignatureAsync(const Napi::CallbackInfo& info);
 Napi::Value SignDataAsync(const Napi::CallbackInfo& info);
 Napi::Value ChangeKeyPasswordAsync(const Napi::CallbackInfo& info);
+Napi::Value QuantoVerifySignatureAsync(const Napi::CallbackInfo& info);
+Napi::Value QuantoSignDataAsync(const Napi::CallbackInfo& info);
 
 #endif  // CHEVRON_ASYNC_H_

--- a/cmd/lib/wraps/nodejs/native/chevronwrap.cc
+++ b/cmd/lib/wraps/nodejs/native/chevronwrap.cc
@@ -2,16 +2,19 @@
 #include <dlfcn.h>
 #include "chevronwrap.h"
 
-UnlockKey_t                     *chevronlib_unlockkey;
-LoadKey_t                       *chevronlib_loadkey;
-VerifySignature_t               *chevronlib_verifysignature;
-VerifyBase64DataSignature_t     *chevronlib_verifybase64datasignature;
-SignData_t                      *chevronlib_signdata;
-SignBase64Data_t                *chevronlib_signbase64data;
-GetKeyFingerprints_t            *chevronlib_getkeyfingerprints;
-ChangeKeyPassword_t             *chevronlib_changekeypassword;
-GetPublicKey_t                  *chevronlib_getpublickey;
-GenerateKey_t                   *chevronlib_generatekey;
+UnlockKey_t                             *chevronlib_unlockkey;
+LoadKey_t                               *chevronlib_loadkey;
+VerifySignature_t                       *chevronlib_verifysignature;
+VerifyBase64DataSignature_t             *chevronlib_verifybase64datasignature;
+SignData_t                              *chevronlib_signdata;
+SignBase64Data_t                        *chevronlib_signbase64data;
+GetKeyFingerprints_t                    *chevronlib_getkeyfingerprints;
+ChangeKeyPassword_t                     *chevronlib_changekeypassword;
+GetPublicKey_t                          *chevronlib_getpublickey;
+GenerateKey_t                           *chevronlib_generatekey;
+QuantoVerifyBase64DataSignature_t       *chevronlib_quantoverifybase64datasignature;
+QuantoSignBase64Data_t                  *chevronlib_quantosignbase64data;
+
 
 void *tryLoad(const char *path, const char *name) {
     std::string fullpath = std::string(path) + "/" + std::string(name);
@@ -57,16 +60,18 @@ void *loadChevronLibDL(const char *path) {
 }
 
 void loadChevronCalls(void *handler) {
-    chevronlib_loadkey                      = (LoadKey_t*)                      dlsym( handler, "LoadKey" );
-    chevronlib_unlockkey                    = (UnlockKey_t*)                    dlsym( handler, "UnlockKey" );
-    chevronlib_verifysignature              = (VerifySignature_t*)              dlsym( handler, "VerifySignature" );
-    chevronlib_verifybase64datasignature    = (VerifyBase64DataSignature_t*)    dlsym( handler, "VerifyBase64DataSignature" );
-    chevronlib_signdata                     = (SignData_t*)                     dlsym( handler, "SignData" );
-    chevronlib_signbase64data               = (SignBase64Data_t*)               dlsym( handler, "SignBase64Data" );
-    chevronlib_getkeyfingerprints           = (GetKeyFingerprints_t*)           dlsym( handler, "GetKeyFingerprints" );
-    chevronlib_changekeypassword            = (ChangeKeyPassword_t*)            dlsym( handler, "ChangeKeyPassword" );
-    chevronlib_getpublickey                 = (GetPublicKey_t*)                 dlsym( handler, "GetPublicKey" );
-    chevronlib_generatekey                  = (GenerateKey_t*)                  dlsym( handler, "GenerateKey" );
+    chevronlib_loadkey                              = (LoadKey_t*)                              dlsym( handler, "LoadKey" );
+    chevronlib_unlockkey                            = (UnlockKey_t*)                            dlsym( handler, "UnlockKey" );
+    chevronlib_verifysignature                      = (VerifySignature_t*)                      dlsym( handler, "VerifySignature" );
+    chevronlib_verifybase64datasignature            = (VerifyBase64DataSignature_t*)            dlsym( handler, "VerifyBase64DataSignature" );
+    chevronlib_signdata                             = (SignData_t*)                             dlsym( handler, "SignData" );
+    chevronlib_signbase64data                       = (SignBase64Data_t*)                       dlsym( handler, "SignBase64Data" );
+    chevronlib_getkeyfingerprints                   = (GetKeyFingerprints_t*)                   dlsym( handler, "GetKeyFingerprints" );
+    chevronlib_changekeypassword                    = (ChangeKeyPassword_t*)                    dlsym( handler, "ChangeKeyPassword" );
+    chevronlib_getpublickey                         = (GetPublicKey_t*)                         dlsym( handler, "GetPublicKey" );
+    chevronlib_generatekey                          = (GenerateKey_t*)                          dlsym( handler, "GenerateKey" );
+    chevronlib_quantoverifybase64datasignature      = (QuantoVerifyBase64DataSignature_t*)      dlsym( handler, "QuantoVerifyBase64DataSignature" );
+    chevronlib_quantosignbase64data                 = (QuantoSignBase64Data_t*)                 dlsym( handler, "QuantoSignBase64Data" );
 }
 
 int loadChevron(const char *path) {

--- a/cmd/lib/wraps/nodejs/native/chevronwrap.h
+++ b/cmd/lib/wraps/nodejs/native/chevronwrap.h
@@ -40,17 +40,21 @@ typedef int                     GetKeyFingerprints_t(char* keyData, char* result
 typedef int                     ChangeKeyPassword_t(char* keyData, char* currentPassword, char* newPassword, char* result, int resultLen);
 typedef int                     GetPublicKey_t(char* fingerprint, char* result, int resultLen);
 typedef int                     GenerateKey_t(char* password, char* identifier, int bits, char* result, int resultLen);
+typedef int                     QuantoVerifyBase64DataSignature_t(char* b64data, char* signature, char* result, int resultLen);
+typedef int                     QuantoSignBase64Data_t(char* b64data, char* fingerprint, char* result, int resultLen);
 
-extern UnlockKey_t                      *chevronlib_unlockkey;
-extern LoadKey_t                        *chevronlib_loadkey;
-extern VerifySignature_t                *chevronlib_verifysignature;
-extern VerifyBase64DataSignature_t      *chevronlib_verifybase64datasignature;
-extern SignData_t                       *chevronlib_signdata;
-extern SignBase64Data_t                 *chevronlib_signbase64data;
-extern GetKeyFingerprints_t             *chevronlib_getkeyfingerprints;
-extern ChangeKeyPassword_t              *chevronlib_changekeypassword;
-extern GetPublicKey_t                   *chevronlib_getpublickey;
-extern GenerateKey_t                    *chevronlib_generatekey;
+extern UnlockKey_t                          *chevronlib_unlockkey;
+extern LoadKey_t                        	*chevronlib_loadkey;
+extern VerifySignature_t                	*chevronlib_verifysignature;
+extern VerifyBase64DataSignature_t      	*chevronlib_verifybase64datasignature;
+extern SignData_t                       	*chevronlib_signdata;
+extern SignBase64Data_t                 	*chevronlib_signbase64data;
+extern GetKeyFingerprints_t             	*chevronlib_getkeyfingerprints;
+extern ChangeKeyPassword_t              	*chevronlib_changekeypassword;
+extern GetPublicKey_t                   	*chevronlib_getpublickey;
+extern GenerateKey_t                    	*chevronlib_generatekey;
+extern QuantoVerifyBase64DataSignature_t    *chevronlib_quantoverifybase64datasignature;
+extern QuantoSignBase64Data_t               *chevronlib_quantosignbase64data;
 
 int loadChevron(const char *path);
 

--- a/cmd/lib/wraps/nodejs/native/nodechevron.cc
+++ b/cmd/lib/wraps/nodejs/native/nodechevron.cc
@@ -29,15 +29,17 @@ Napi::Value LoadNative(const Napi::CallbackInfo& info) {
 
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
-    exports.Set(Napi::String::New(env, "__loadnative"),         Napi::Function::New(env, LoadNative));
-    exports.Set(Napi::String::New(env, "generateKey"),          Napi::Function::New(env, GenerateKeyAsync));
-    exports.Set(Napi::String::New(env, "loadKey"),              Napi::Function::New(env, LoadKeyAsync));
-    exports.Set(Napi::String::New(env, "unlockKey"),            Napi::Function::New(env, UnlockKeyAsync));
-    exports.Set(Napi::String::New(env, "getKeyFingerprints"),   Napi::Function::New(env, GetKeyFingerprintsSync));
-    exports.Set(Napi::String::New(env, "getPublicKey"),         Napi::Function::New(env, GetPublicKeySync));
-    exports.Set(Napi::String::New(env, "verifySignature"),      Napi::Function::New(env, VerifySignatureAsync));
-    exports.Set(Napi::String::New(env, "signData"),             Napi::Function::New(env, SignDataAsync));
-    exports.Set(Napi::String::New(env, "changeKeyPassword"),    Napi::Function::New(env, ChangeKeyPasswordAsync));
+    exports.Set(Napi::String::New(env, "__loadnative"),             Napi::Function::New(env, LoadNative));
+    exports.Set(Napi::String::New(env, "generateKey"),              Napi::Function::New(env, GenerateKeyAsync));
+    exports.Set(Napi::String::New(env, "loadKey"),                  Napi::Function::New(env, LoadKeyAsync));
+    exports.Set(Napi::String::New(env, "unlockKey"),                Napi::Function::New(env, UnlockKeyAsync));
+    exports.Set(Napi::String::New(env, "getKeyFingerprints"),       Napi::Function::New(env, GetKeyFingerprintsSync));
+    exports.Set(Napi::String::New(env, "getPublicKey"),             Napi::Function::New(env, GetPublicKeySync));
+    exports.Set(Napi::String::New(env, "verifySignature"),          Napi::Function::New(env, VerifySignatureAsync));
+    exports.Set(Napi::String::New(env, "signData"),                 Napi::Function::New(env, SignDataAsync));
+    exports.Set(Napi::String::New(env, "changeKeyPassword"),        Napi::Function::New(env, ChangeKeyPasswordAsync));
+    exports.Set(Napi::String::New(env, "quantoSignData"),           Napi::Function::New(env, QuantoSignDataAsync));
+    exports.Set(Napi::String::New(env, "quantoVerifySignature"),    Napi::Function::New(env, QuantoVerifySignatureAsync));
 
     return exports;
 };

--- a/cmd/lib/wraps/nodejs/package-lock.json
+++ b/cmd/lib/wraps/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quan-to/chevronlib",
-  "version": "1.3.0",
+  "version": "1.3.0a",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cmd/lib/wraps/nodejs/package.json
+++ b/cmd/lib/wraps/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quan-to/chevronlib",
-  "version": "1.3.0a",
+  "version": "1.3.1",
   "description": "Chevron GPG Library Wrapper for Node.JS",
   "main": "dist/index.js",
   "scripts": {

--- a/cmd/lib/wraps/nodejs/src/index.test.ts
+++ b/cmd/lib/wraps/nodejs/src/index.test.ts
@@ -253,3 +253,23 @@ test('sign quanto invalid key', async() => {
 
     return chevron.quantoSignData(toBase64(payloadToSign), "DEADBEEF1234").catch((res: string) => expect(typeof res).toBe('string'));
 });
+
+
+test('change key password', async() => {
+    expect.assertions(1);
+    const tmpPass = '0912345aseuahse';
+    const key = await chevron.generateKey(tmpPass, tmpPass, 2048);
+
+    const newKey = await chevron.changeKeyPassword(key, tmpPass, testKeyPassword);
+    const fp = await chevron.loadKey(newKey);
+
+    return chevron.unlockKey(fp, testKeyPassword).then((res: string|void) => expect(typeof res).toBe("string"));
+});
+
+test('change key password invalid', async() => {
+    expect.assertions(1);
+    const tmpPass = '0912345aseuahse';
+    const key = await chevron.generateKey(tmpPass, tmpPass, 2048);
+
+    return chevron.changeKeyPassword(key, testKeyPassword, tmpPass).catch((res: string) => expect(typeof res).toBe("string"));
+});

--- a/cmd/lib/wraps/nodejs/src/index.ts
+++ b/cmd/lib/wraps/nodejs/src/index.ts
@@ -151,6 +151,61 @@ const generateKey = async function(password: string, identifier: string, bits: n
  */
 const getPublicKey = (fingerprint: string) : string => lib.getPublicKey(fingerprint);
 
+
+/**
+ * Signs the specified data using a pre-loaded and pre-unlocked key specified by fingerprint
+ * and returns in Quanto Signature Format
+ *
+ * The key should be previously loaded with loadKey and unlocked with unlockKey
+ * The data should be always encoded as base64
+ *
+ * @param {string} data - Base64 Encoded Data to be signed
+ * @param {string} fingerprint - Fingerprint of the key used to sign data
+ * @returns {Promise<string>} - The ASCII Armored PGP Signature
+ */
+const quantoSignData = async function(data: string, fingerprint: string) : Promise<string> {
+    return new Promise((resolve, reject) => {
+        if (!isBase64(data)) {
+            return reject('Expected a base64 encoded data');
+        }
+        lib.quantoSignData(data, fingerprint, (error: string|void, result: any|void) => {
+            if (error) {
+                return reject(error);
+            }
+
+            return resolve(result);
+        });
+    });
+};
+
+/**
+ * Verifies the signature in Quanto Signature Format of a payload and returns true if it's valid.
+ *
+ * The data should be always encoded as base64
+ * The signature field can be in ASCII Armored Format or base64 encoded binary PGP Signature
+ *
+ * @param {string} data - Base64 Encoded Data to be signed
+ * @param {string} signature - A ASCII Armored Format or Base64 Encoded Binary PGP Signature
+ * @returns {Promise<boolean>}
+ */
+const quantoVerifySignature = async function(data: string, signature: string) : Promise<boolean|void> {
+    return new Promise((resolve, reject) => {
+        if (!isBase64(data)) {
+            return reject('Expected a base64 encoded data');
+        }
+        lib.quantoVerifySignature(data, signature, (error: string|void, result: boolean|void) => {
+            if (error) {
+                if (error.indexOf('invalid signature') > -1) {
+                    return resolve(false);
+                }
+                return reject(error);
+            }
+
+            return resolve(result);
+        });
+    });
+};
+
 export {
     verifySignature,
     signData,
@@ -160,4 +215,6 @@ export {
     generateKey,
     getPublicKey,
     isBase64,
+    quantoSignData,
+    quantoVerifySignature
 };

--- a/cmd/lib/wraps/nodejs/src/index.ts
+++ b/cmd/lib/wraps/nodejs/src/index.ts
@@ -206,6 +206,26 @@ const quantoVerifySignature = async function(data: string, signature: string) : 
     });
 };
 
+/**
+ * Changes a private key password
+ *
+ * @param {string} keyData - The private key
+ * @param {string} currentPassword - The current password of the key
+ * @param {string} newPassword - The new password for the key
+ * @returns {Promise<string>>} the same private key encrypted with the newPassword
+ */
+const changeKeyPassword = async function(keyData: string, currentPassword: string, newPassword: string): Promise<string|void> {
+    return new Promise((resolve, reject) => {
+        lib.changeKeyPassword(keyData, currentPassword, newPassword, (error: string|void, result: string|void) => {
+            if (error) {
+                return reject(error);
+            }
+
+            return resolve(result);
+        });
+    });
+};
+
 export {
     verifySignature,
     signData,
@@ -216,5 +236,6 @@ export {
     getPublicKey,
     isBase64,
     quantoSignData,
-    quantoVerifySignature
+    quantoVerifySignature,
+    changeKeyPassword,
 };

--- a/etc/krmInterface.go
+++ b/etc/krmInterface.go
@@ -13,4 +13,5 @@ type KRMInterface interface {
 	GetKey(ctx context.Context, fp string) *openpgp.Entity
 	AddKey(ctx context.Context, key *openpgp.Entity, nonErasable bool)
 	GetFingerPrints(ctx context.Context) []string
+	DeleteKey(ctx context.Context, fp string) error
 }

--- a/etc/pgpInterface.go
+++ b/etc/pgpInterface.go
@@ -19,12 +19,13 @@ type PGPInterface interface {
 	GetLoadedPrivateKeys(ctx context.Context) []models.KeyInfo
 	GetLoadedKeys() []models.KeyInfo
 	SaveKey(fingerPrint, armoredData string, password interface{}) error
-	DeleteKey(fingerPrint string) error
+	DeleteKey(ctx context.Context, fingerPrint string) error
 	SignData(ctx context.Context, fingerPrint string, data []byte, hashAlgorithm crypto.Hash) (string, error)
 	GetPublicKeyEntity(ctx context.Context, fingerPrint string) *openpgp.Entity
 	GetPublicKey(ctx context.Context, fingerPrint string) *packet.PublicKey
 	GetPublicKeyAscii(ctx context.Context, fingerPrint string) (string, error)
 	GetPrivateKeyAscii(ctx context.Context, fingerPrint, password string) (string, error)
+	GetPrivateKeyAsciiReencrypt(ctx context.Context, fingerPrint, currentPassword, newPassword string) (string, error)
 	VerifySignatureStringData(ctx context.Context, data string, signature string) (bool, error)
 	VerifySignature(ctx context.Context, data []byte, signature string) (bool, error)
 	GeneratePGPKey(ctx context.Context, identifier, password string, numBits int) (string, error)

--- a/keymagic/keyRingManager.go
+++ b/keymagic/keyRingManager.go
@@ -2,6 +2,7 @@ package keymagic
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	remote_signer "github.com/quan-to/chevron"
@@ -101,6 +102,20 @@ func (krm *KeyRingManager) AddKey(ctx context.Context, key *openpgp.Entity, nonE
 		log.Debug("	Adding also subkey %s", subfp)
 		krm.AddKey(ctx, subE, nonErasable)
 	}
+}
+
+func (krm *KeyRingManager) DeleteKey(ctx context.Context, fp string) error {
+	requestID := remote_signer.GetRequestIDFromContext(ctx)
+	log := krm.log.Tag(requestID)
+	log.DebugNote("DeleteKey(%s)", fp)
+	krm.Lock()
+	if _, ok := krm.entities[fp]; ok {
+		log.Info("Deleting key %s from memory", fp)
+		delete(krm.entities, fp)
+	}
+	krm.Unlock()
+
+	return fmt.Errorf("key %s not found", fp)
 }
 
 func (krm *KeyRingManager) GetCachedKeys(ctx context.Context) []models.KeyInfo {

--- a/keymagic/pgpManager.go
+++ b/keymagic/pgpManager.go
@@ -464,7 +464,7 @@ func (pm *PGPManager) DeleteKey(ctx context.Context, fingerPrint string) error {
 	}
 	pm.Unlock()
 
-	pm.krm.DeleteKey(ctx, fingerPrint)
+	_ = pm.krm.DeleteKey(ctx, fingerPrint)
 
 	_, _, err := pm.kbkend.Read(fingerPrint)
 	if err != nil {

--- a/server/keyRingEndpoint.go
+++ b/server/keyRingEndpoint.go
@@ -125,6 +125,7 @@ func (kre *KeyRingEndpoint) getLoadedPrivateKeys(w http.ResponseWriter, r *http.
 
 func (kre *KeyRingEndpoint) deletePrivateKey(w http.ResponseWriter, r *http.Request) {
 	var data models.KeyRingDeletePrivateKeyData
+	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(kre.log, r)
 	InitHTTPTimer(log, r)
 
@@ -138,7 +139,7 @@ func (kre *KeyRingEndpoint) deletePrivateKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	err := kre.gpg.DeleteKey(data.FingerPrint)
+	err := kre.gpg.DeleteKey(ctx, data.FingerPrint)
 	if err != nil {
 		log.Error("Error deleting key: %s", err)
 		InternalServerError("There was an error deleting your key from the disk.", data, w, r, log)


### PR DESCRIPTION
* Add NodeJS Wrapper calls: `changeKeyPassword`, `quantoSignData`, `quantoVerifySignature`
* Fixes the behaviour of `DeleteKey` and `ChangeKeyPassword` in ChevronLib

After this is merged, merge to master and bump to 1.3.1 (same as NodeJS)