### PR TITLE
[FIX] Agent Proxy UUID / Timestamp Generation

### DIFF
--- a/server/agentProxy.go
+++ b/server/agentProxy.go
@@ -47,19 +47,17 @@ func MakeAgentProxy(log slog.Instance, gpg etc.PGPInterface, tm etc.TokenManager
 
 func generateUUID(log slog.Instance) (string, error) {
 	uniqueString := ""
-	tries := 0
 
-	for len(uniqueString) == 0 && tries < maxUUIDTries {
+	for tries := 0; tries < maxUUIDTries; tries++ {
 		u, err := uuid.NewRandom()
-		if err != nil {
-			log.Warn("Error generating UUID: %q. Trying again", err)
-			tries++
-			continue
+		if err == nil {
+			uniqueString = u.String()
+			break
 		}
-		uniqueString = u.String()
+		log.Warn("Error generating UUID: %q. Trying again", err)
 	}
 
-	if tries == maxUUIDTries || len(uniqueString) == 0 {
+	if len(uniqueString) == 0 {
 		return "", fmt.Errorf("cannot generate uuid. max tries reached")
 	}
 

--- a/server/agentProxy.go
+++ b/server/agentProxy.go
@@ -45,7 +45,6 @@ func MakeAgentProxy(log slog.Instance, gpg etc.PGPInterface, tm etc.TokenManager
 }
 
 func injectUniquenessFields(log slog.Instance, json map[string]interface{}) {
-	json["_timestamp"] = time.Now().UnixNano() / 1e6
 	uniqueString := ""
 	tries := 0
 	for len(uniqueString) == 0 && tries < MaxUUIDTries {
@@ -64,6 +63,8 @@ func injectUniquenessFields(log slog.Instance, json map[string]interface{}) {
 	}
 
 	json["_timeUniqueId"] = uniqueString
+	json["_timestamp"] = time.Now().UnixNano() / 1e6
+	log.DebugNote("Request UUID: %q - RequestTimestamp: %d", json["_timeUniqueId"], json["_timestamp"])
 }
 
 func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/agentProxy.go
+++ b/server/agentProxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/quan-to/slog"
 )
 
-const MaxUUIDTries = 5
+const maxUUIDTries = 5
 
 type AgentProxy struct {
 	gpg       etc.PGPInterface
@@ -47,7 +47,7 @@ func MakeAgentProxy(log slog.Instance, gpg etc.PGPInterface, tm etc.TokenManager
 func injectUniquenessFields(log slog.Instance, json map[string]interface{}) {
 	uniqueString := ""
 	tries := 0
-	for len(uniqueString) == 0 && tries < MaxUUIDTries {
+	for len(uniqueString) == 0 && tries < maxUUIDTries {
 		u, err := uuid.NewRandom()
 		if err != nil {
 			log.Warn("Error generating UUID: %q. Trying again", err)


### PR DESCRIPTION
Since the `google/uuid` library uses `crypto/rand` to generate UUIDs, there is a tiny possibility to return an error. We were ignoring this error which would break the request if google returned `nil`. But instead google was returning `Nil` which is a `UUID` filled with zeros.

That could break some requests going to target url. Since of that, we're now retrying generating UUID (5 times) and the timestamp now uses UnixNano / 1e6 instead Unix * 1e3. This should also give more precision in timestamp checks.