### PR TITLE
[FIX] Signature Checking - Fix EOF on no public key available for checking

### DIFF
--- a/server/gpgEndpoints.go
+++ b/server/gpgEndpoints.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	remote_signer "github.com/quan-to/chevron"
@@ -181,6 +182,10 @@ func (ge *GPGEndpoint) verifySignatureQuanto(w http.ResponseWriter, r *http.Requ
 	valid, err := ge.gpg.VerifySignature(ctx, bytes, signature)
 
 	if err != nil {
+		if strings.Contains(err.Error(), "cannot find public key to verify signature") {
+			NotFound("publicKey", err.Error(), w, r, log)
+			return
+		}
 		InvalidFieldData("Signature", err.Error(), w, r, log)
 		return
 	}


### PR DESCRIPTION
Before, if you tried to check a signature that you don't have the public key, it would return an EOF like this:

```json
{
    "errorCode": "INVALID_FIELD_DATA",
    "errorField": "Signature",
    "message": "EOF",
    "errorData": null,
    "stackTrace":  null,
}
```

Now:

```json
{
"errorCode": "NOT_FOUND",
"errorField": "publicKey",
"message": "cannot find public key for any of these signatures: 2EE64F8DDDD2FEAE",
"errorData": null,
"stackTrace":  null
}
```