### PR TITLE
feat(server): Add single key server mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	bou.ke/monkey v1.0.2 // indirect
-	github.com/akavel/rsrc v0.8.0 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/asticode/go-astiamqp v1.0.0 // indirect
@@ -12,8 +11,6 @@ require (
 	github.com/asticode/go-astilectron v0.13.1
 	github.com/asticode/go-astilectron-bootstrap v0.3.4
 	github.com/asticode/go-astilectron-bundler v0.5.2
-	github.com/bitly/go-hostpool v0.1.0 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bouk/monkey v1.0.1
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
@@ -32,12 +29,10 @@ require (
 	github.com/mewkiz/pkg v0.0.0-20200212014339-e3282939ac6c
 	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/quan-to/slog v0.1.1
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -55,6 +55,9 @@ var Environment string
 var AgentExternalURL string
 var AgentAdminExternalURL string
 var ShowLines bool
+var SingleKeyMode bool
+var SingleKeyPath string
+var SingleKeyPassword string
 
 // LogFormat allows to configure the output log format
 var LogFormat slog.Format
@@ -171,6 +174,10 @@ func Setup() {
 	}
 
 	OnDemandKeyLoad = os.Getenv("ON_DEMAND_KEY_LOAD") == "true"
+
+	SingleKeyMode = os.Getenv("MODE") == "single_key"
+	SingleKeyPath = os.Getenv("SINGLE_KEY_PATH")
+	SingleKeyPassword = os.Getenv("SINGLE_KEY_PASSWORD")
 
 	// Set defaults if not defined
 	if SyslogServer == "" {

--- a/internal/etc/magicbuilder/pgp_wasm.go
+++ b/internal/etc/magicbuilder/pgp_wasm.go
@@ -8,13 +8,13 @@ import (
 )
 
 // MakePGP creates a new PGPManager using environment variables KeyPrefix, PrivateKeyFolder
-func MakePGP() interfaces.PGPManager {
-	kb := keybackend.MakeSaveToDiskBackend(nil, config.PrivateKeyFolder, config.KeyPrefix)
+func MakePGP(log slog.Instance) interfaces.PGPManager {
+	kb := keybackend.MakeSaveToDiskBackend(log, config.PrivateKeyFolder, config.KeyPrefix)
 
-	return keymagic.MakePGPManager(nil, kb, keymagic.MakeKeyRingManager())
+	return keymagic.MakePGPManager(log, kb, keymagic.MakeKeyRingManager())
 }
 
 // MakeVoidPGP creates a PGPManager that does not store anything anywhere
-func MakeVoidPGP() interfaces.PGPManager {
-	return keymagic.MakePGPManager(nil, keybackend.MakeVoidBackend(), keymagic.MakeKeyRingManager())
+func MakeVoidPGP(log slog.Instance) interfaces.PGPManager {
+	return keymagic.MakePGPManager(log, keybackend.MakeVoidBackend(), keymagic.MakeKeyRingManager())
 }


### PR DESCRIPTION
With this new mode, someone can run a remote-signer server for a single key just by setting few environment variables:

```bash
MODE=single_key SINGLE_KEY_PATH=key.gpg SINGLE_KEY_PASSWORD=123456 ./server
```

This will load `key.gpg`, decrypt with the specified password and set as default Agent Key.