### PR TITLE
[FEAT] | 98 - Add fields structured log

### DIFF
--- a/internal/server/agentAdminEndpoint.go
+++ b/internal/server/agentAdminEndpoint.go
@@ -106,7 +106,6 @@ func (gi *graphIntercept) WriteHeader(statusCode int) {
 // @Router /agentAdmin [post]
 func (admin *AgentAdmin) handleGraphQL(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(admin.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -130,7 +129,6 @@ func (admin *AgentAdmin) handleGraphQL(w http.ResponseWriter, r *http.Request) {
 		ctx = context.WithValue(ctx, agent.LoggedUserKey, user)
 	}
 	admin.handler.ContextHandler(ctx, &gi, r)
-	LogExit(log, r, gi.StatusCode, gi.WrittenBytes)
 }
 
 func (admin *AgentAdmin) AddHandlers(r *mux.Router) {

--- a/internal/server/agentProxy.go
+++ b/internal/server/agentProxy.go
@@ -212,6 +212,7 @@ func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	log.Info("Sending response")
+	w.WriteHeader(http.StatusOK)
 	io.Copy(w, res.Body)
 }
 

--- a/internal/server/agentProxy.go
+++ b/internal/server/agentProxy.go
@@ -213,7 +213,7 @@ func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) 
 
 	log.Info("Sending response")
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, res.Body)
+	_, _ = io.Copy(w, res.Body)
 }
 
 func (proxy *AgentProxy) AddHandlers(r *mux.Router) {

--- a/internal/server/agentProxy.go
+++ b/internal/server/agentProxy.go
@@ -72,7 +72,6 @@ func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) 
 
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(proxy.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -213,8 +212,7 @@ func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	log.Info("Sending response")
-	n, _ := io.Copy(w, res.Body)
-	LogExit(log, r, res.StatusCode, int(n))
+	io.Copy(w, res.Body)
 }
 
 func (proxy *AgentProxy) AddHandlers(r *mux.Router) {

--- a/internal/server/agentProxy.go
+++ b/internal/server/agentProxy.go
@@ -212,7 +212,7 @@ func (proxy *AgentProxy) defaultHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	log.Info("Sending response")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(res.StatusCode)
 	_, _ = io.Copy(w, res.Body)
 }
 

--- a/internal/server/gpgEndpoints.go
+++ b/internal/server/gpgEndpoints.go
@@ -84,7 +84,7 @@ func (ge *GPGEndpoint) decrypt(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(d)
+	_, _ = w.Write(d)
 }
 
 // Encrypt godoc
@@ -128,7 +128,7 @@ func (ge *GPGEndpoint) encrypt(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(encrypted))
+	_, _ = w.Write([]byte(encrypted))
 }
 
 // VerifySignature godoc
@@ -177,7 +177,7 @@ func (ge *GPGEndpoint) verifySignature(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 // VerifySignatureQuanto godoc
@@ -231,7 +231,7 @@ func (ge *GPGEndpoint) verifySignatureQuanto(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 // Sign godoc
@@ -276,7 +276,7 @@ func (ge *GPGEndpoint) sign(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(signature))
+	_, _ = w.Write([]byte(signature))
 }
 
 // SignQuanto godoc
@@ -323,7 +323,7 @@ func (ge *GPGEndpoint) signQuanto(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(quantoSig))
+	_, _ = w.Write([]byte(quantoSig))
 }
 
 // UnlockKey godoc
@@ -365,7 +365,7 @@ func (ge *GPGEndpoint) unlockKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 // GenerateKey godoc
@@ -413,5 +413,5 @@ func (ge *GPGEndpoint) generateKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(key))
+	_, _ = w.Write([]byte(key))
 }

--- a/internal/server/gpgEndpoints.go
+++ b/internal/server/gpgEndpoints.go
@@ -61,7 +61,6 @@ func (ge *GPGEndpoint) AttachHandlers(r *mux.Router) {
 func (ge *GPGEndpoint) decrypt(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 
 	var data models.GPGDecryptData
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -85,8 +84,7 @@ func (ge *GPGEndpoint) decrypt(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(d)
-	LogExit(log, r, 200, n)
+	w.Write(d)
 }
 
 // Encrypt godoc
@@ -102,7 +100,6 @@ func (ge *GPGEndpoint) decrypt(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) encrypt(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGEncryptData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -131,8 +128,7 @@ func (ge *GPGEndpoint) encrypt(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(encrypted))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(encrypted))
 }
 
 // VerifySignature godoc
@@ -148,7 +144,6 @@ func (ge *GPGEndpoint) encrypt(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) verifySignature(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGVerifySignatureData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -182,8 +177,7 @@ func (ge *GPGEndpoint) verifySignature(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }
 
 // VerifySignatureQuanto godoc
@@ -199,7 +193,6 @@ func (ge *GPGEndpoint) verifySignature(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) verifySignatureQuanto(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGVerifySignatureData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -238,8 +231,7 @@ func (ge *GPGEndpoint) verifySignatureQuanto(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }
 
 // Sign godoc
@@ -256,7 +248,6 @@ func (ge *GPGEndpoint) verifySignatureQuanto(w http.ResponseWriter, r *http.Requ
 func (ge *GPGEndpoint) sign(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGSignData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -285,8 +276,7 @@ func (ge *GPGEndpoint) sign(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(signature))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(signature))
 }
 
 // SignQuanto godoc
@@ -303,7 +293,6 @@ func (ge *GPGEndpoint) sign(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) signQuanto(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGSignData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -334,8 +323,7 @@ func (ge *GPGEndpoint) signQuanto(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(quantoSig))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(quantoSig))
 }
 
 // UnlockKey godoc
@@ -352,7 +340,6 @@ func (ge *GPGEndpoint) signQuanto(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) unlockKey(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGUnlockKeyData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -378,8 +365,7 @@ func (ge *GPGEndpoint) unlockKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }
 
 // GenerateKey godoc
@@ -396,7 +382,6 @@ func (ge *GPGEndpoint) unlockKey(w http.ResponseWriter, r *http.Request) {
 func (ge *GPGEndpoint) generateKey(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ge.log, r)
-	InitHTTPTimer(log, r)
 	var data models.GPGGenerateKeyData
 
 	if !UnmarshalBodyOrDie(&data, w, r, log) {
@@ -428,6 +413,5 @@ func (ge *GPGEndpoint) generateKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(key))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(key))
 }

--- a/internal/server/hkpmanager.go
+++ b/internal/server/hkpmanager.go
@@ -127,7 +127,7 @@ func hkpLookup(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(result))
+	_, _ = w.Write([]byte(result))
 }
 
 // HKP Add key godoc
@@ -157,7 +157,7 @@ func hkpAdd(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	result := keymagic.PKSAdd(ctx, key)
 	log.Done("Key add result: %s", result)
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(result))
+	_, _ = w.Write([]byte(result))
 }
 
 // AddHKPEndpoints attach the HKP /lookup and /add endpoints to the specified router with the specified log wrapped into the calls

--- a/internal/server/hkpmanager.go
+++ b/internal/server/hkpmanager.go
@@ -62,7 +62,6 @@ func hkpLookup(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log = wrapLogWithRequestID(log.SubScope("HKP"), r)
 
-	InitHTTPTimer(log, r)
 	q := r.URL.Query()
 	op := q.Get("op")
 	options := q.Get("options")
@@ -128,8 +127,7 @@ func hkpLookup(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(result))
-	LogExit(log, r, http.StatusOK, len(result))
+	w.Write([]byte(result))
 }
 
 // HKP Add key godoc
@@ -146,7 +144,6 @@ func hkpAdd(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log = wrapLogWithRequestID(log.SubScope("HKP"), r)
 
-	InitHTTPTimer(log, r)
 	log.Await("Parsing Form Fields")
 	err := r.ParseForm()
 	log.Done("Parsed")
@@ -160,8 +157,7 @@ func hkpAdd(log slog.Instance, w http.ResponseWriter, r *http.Request) {
 	result := keymagic.PKSAdd(ctx, key)
 	log.Done("Key add result: %s", result)
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(result))
-	LogExit(log, r, http.StatusOK, len(result))
+	w.Write([]byte(result))
 }
 
 // AddHKPEndpoints attach the HKP /lookup and /add endpoints to the specified router with the specified log wrapped into the calls

--- a/internal/server/httpmiddlewares.go
+++ b/internal/server/httpmiddlewares.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"fmt"
+	"github.com/quan-to/slog"
+	"net"
+	"net/http"
+	"time"
+)
+
+// ResponseWriter is a http.ResponseWriter wrapper that provides the status code info.
+type ResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+// WriteHeader implements the http.ResponseWriter WriteHeader function. It makes enable to store the response status code.
+func (rw *ResponseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func wrapResponseWriter(w http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{ResponseWriter: w}
+}
+
+// LoggingMiddleware is a HTTP middleware that logs the entry and exit requests
+func LoggingMiddleware(next http.Handler) http.Handler {
+	log := slog.Scope("LoggingMiddleware")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		startTime := time.Now()
+
+		host, _, _ := net.SplitHostPort(r.RemoteAddr)
+
+		logParams := map[string]interface{}{
+			"endpoint": r.URL.Path,
+			"method":   r.Method,
+			"host":     host,
+		}
+
+		log = log.WithFields(logParams)
+
+		log.Await("incoming request %s %s", r.Method, r.URL.Path)
+
+		rw := wrapResponseWriter(w)
+		next.ServeHTTP(rw, r)
+
+		duration := time.Since(startTime)
+
+		logParams["statusCode"] = fmt.Sprint(rw.status)
+		logParams["elapsedTime"] = duration.Milliseconds()
+
+		log.Done("Finished request %s - %s - %d", r.Method, r.URL.Path, rw.status)
+	})
+}

--- a/internal/server/httpmiddlewares.go
+++ b/internal/server/httpmiddlewares.go
@@ -2,16 +2,17 @@ package server
 
 import (
 	"fmt"
-	"github.com/quan-to/slog"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/quan-to/slog"
 )
 
 // ResponseWriter is a http.ResponseWriter wrapper that provides the status code and content length info.
 type ResponseWriter struct {
 	http.ResponseWriter
-	status int
+	status        int
 	contentLength int
 }
 

--- a/internal/server/httpmiddlewares_test.go
+++ b/internal/server/httpmiddlewares_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/quan-to/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestLoggingMiddleware stores the middleware logs in a buffer and validates their contents
+func TestLoggingMiddleware(t *testing.T) {
+	var logBuffer bytes.Buffer
+	slog.UnsetTestMode()
+	slog.SetDefaultOutput(&logBuffer)
+	slog.SetLogFormat(slog.JSON)
+
+	expectedScope := "LoggingMiddleware"
+	expectedHTTPMethod := http.MethodPost
+	someURL, _ := url.Parse("http://huehuebr.com/resource/subresource")
+	expectedCode := 200
+	waitMs := float64(150)
+
+	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Duration(waitMs) * time.Millisecond)
+		w.WriteHeader(expectedCode)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, someURL.String(), nil)
+
+	LoggingMiddleware(mockHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+	if logBuffer.Len() == 0 {
+		t.Fatalf("No logs found in middleware")
+	}
+
+	// each line is a log (1: incoming request. 2: finished request)
+	scanner := bufio.NewScanner(&logBuffer)
+	for scanner.Scan() {
+
+		var logMap map[string]interface{}
+		if err := json.Unmarshal(scanner.Bytes(), &logMap); err != nil {
+			t.Fatalf("error on unmarshal log result: %s. captured logs: %s", err, logBuffer.String())
+		}
+
+		currentScope := logMap["scope"]
+		if currentScope != expectedScope {
+			t.Fatalf("[scope] Got %s; want %s", currentScope, expectedScope)
+		}
+
+		currentURL := logMap["url"]
+		expectURL := someURL.Path
+		if currentURL != expectURL {
+			t.Fatalf("[url] Got %s; want %s", currentURL, expectURL)
+		}
+
+		currentMethod := logMap["method"]
+		if currentMethod != expectedHTTPMethod {
+			t.Fatalf("[http method] Got %s; want %s", currentMethod, expectedHTTPMethod)
+		}
+
+		// DONE op means a finished request
+		if logMap["op"] != "DONE" {
+			continue
+		}
+
+		currentStatus := logMap["statusCode"]
+		if fmt.Sprint(currentStatus) != fmt.Sprint(expectedCode) {
+			t.Fatalf("[status code] Got %s; want %v", currentStatus, expectedCode)
+		}
+
+		currentResponseTime := logMap["responseTime"].(float64)
+		if currentResponseTime < waitMs {
+			t.Fatalf("[response time] Got %f; want greater than %f", currentResponseTime, waitMs)
+		}
+
+	}
+
+	slog.SetTestMode()
+	slog.SetLogFormat(slog.PIPE)
+}

--- a/internal/server/httpmiddlewares_test.go
+++ b/internal/server/httpmiddlewares_test.go
@@ -78,7 +78,7 @@ func TestLoggingMiddleware(t *testing.T) {
 		currentContentLength := logMap["contentLength"]
 		expectedContentLength := len(someResponse)
 		if fmt.Sprint(currentContentLength) != fmt.Sprint(expectedContentLength) {
-			t.Fatalf("[status code] Got %s; want %v", currentContentLength, expectedContentLength)
+			t.Fatalf("[content length] Got %s; want %v", currentContentLength, expectedContentLength)
 		}
 
 		currentStatus := logMap["statusCode"]

--- a/internal/server/httpmiddlewares_test.go
+++ b/internal/server/httpmiddlewares_test.go
@@ -5,13 +5,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/quan-to/chevron/internal/config"
-	"github.com/quan-to/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/quan-to/chevron/internal/config"
+	"github.com/quan-to/slog"
 )
 
 // TestLoggingMiddleware stores the middleware logs in a buffer and validates their contents
@@ -33,7 +34,7 @@ func TestLoggingMiddleware(t *testing.T) {
 	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(time.Duration(waitMs) * time.Millisecond)
 		w.WriteHeader(expectedCode)
-		w.Write(someResponse)
+		_, _ = w.Write(someResponse)
 	})
 
 	req := httptest.NewRequest(http.MethodPost, someURL.String(), nil)
@@ -59,10 +60,10 @@ func TestLoggingMiddleware(t *testing.T) {
 			t.Fatalf("[scope] Got %s; want %s", currentScope, expectedScope)
 		}
 
-		currentURL := logMap["endpoint"]
-		expectURL := someURL.Path
-		if currentURL != expectURL {
-			t.Fatalf("[url] Got %s; want %s", currentURL, expectURL)
+		currentEndpoint := logMap["endpoint"]
+		expectedEndpoint := someURL.Path
+		if currentEndpoint != expectedEndpoint {
+			t.Fatalf("[endpoint] Got %s; want %s", currentEndpoint, expectedEndpoint)
 		}
 
 		currentMethod := logMap["method"]

--- a/internal/server/httptools.go
+++ b/internal/server/httptools.go
@@ -52,8 +52,7 @@ func WriteJSON(data interface{}, statusCode int, w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(statusCode)
-	n, _ := w.Write(b)
-	LogExit(logI, r, statusCode, n)
+	w.Write(b)
 }
 
 // UnmarshalBodyOrDie tries to unmarshal the request body into the specified interface and returns InvalidFieldData to the client if something is wrong

--- a/internal/server/httptools.go
+++ b/internal/server/httptools.go
@@ -176,10 +176,10 @@ func wrapContextWithRequestID(r *http.Request) context.Context {
 }
 
 func wrapLogWithRequestID(log slog.Instance, r *http.Request) slog.Instance {
-	id, ok := r.Header[config.RequestIDHeader]
-	if ok && len(id) >= 1 {
+	id := r.Header.Get(config.RequestIDHeader)
+	if id != "" {
 		// Tag the log
-		return log.Tag(id[0])
+		return log.Tag(id)
 	}
 
 	return log.Tag(tools.DefaultTag)

--- a/internal/server/httptools.go
+++ b/internal/server/httptools.go
@@ -52,7 +52,7 @@ func WriteJSON(data interface{}, statusCode int, w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(statusCode)
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
 // UnmarshalBodyOrDie tries to unmarshal the request body into the specified interface and returns InvalidFieldData to the client if something is wrong

--- a/internal/server/internalEndpoint.go
+++ b/internal/server/internalEndpoint.go
@@ -52,7 +52,7 @@ func (ie *InternalEndpoint) triggerKeyUnlock(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 func (ie *InternalEndpoint) getUnlockPasswords(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +71,7 @@ func (ie *InternalEndpoint) getUnlockPasswords(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 func (ie *InternalEndpoint) postUnlockPasswords(w http.ResponseWriter, r *http.Request) {
@@ -96,5 +96,5 @@ func (ie *InternalEndpoint) postUnlockPasswords(w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }

--- a/internal/server/internalEndpoint.go
+++ b/internal/server/internalEndpoint.go
@@ -41,7 +41,6 @@ func (ie *InternalEndpoint) AttachHandlers(r *mux.Router) {
 func (ie *InternalEndpoint) triggerKeyUnlock(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ie.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -53,14 +52,12 @@ func (ie *InternalEndpoint) triggerKeyUnlock(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }
 
 func (ie *InternalEndpoint) getUnlockPasswords(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ie.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -74,14 +71,12 @@ func (ie *InternalEndpoint) getUnlockPasswords(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 func (ie *InternalEndpoint) postUnlockPasswords(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(ie.log, r)
-	InitHTTPTimer(log, r)
 
 	var passwords map[string]string
 
@@ -101,6 +96,5 @@ func (ie *InternalEndpoint) postUnlockPasswords(w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }

--- a/internal/server/jsonFieldCipher.go
+++ b/internal/server/jsonFieldCipher.go
@@ -53,7 +53,6 @@ func (jfc *JFCEndpoint) AttachHandlers(r *mux.Router) {
 func (jfc *JFCEndpoint) cipher(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(jfc.log, r)
-	InitHTTPTimer(log, r)
 
 	var data models.FieldCipherInput
 
@@ -96,8 +95,7 @@ func (jfc *JFCEndpoint) cipher(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(d))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(d))
 }
 
 // Field Decipher godoc
@@ -113,7 +111,6 @@ func (jfc *JFCEndpoint) cipher(w http.ResponseWriter, r *http.Request) {
 func (jfc *JFCEndpoint) decipher(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(jfc.log, r)
-	InitHTTPTimer(log, r)
 
 	var data models.FieldDecipherInput
 
@@ -156,6 +153,5 @@ func (jfc *JFCEndpoint) decipher(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(d))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(d))
 }

--- a/internal/server/jsonFieldCipher.go
+++ b/internal/server/jsonFieldCipher.go
@@ -95,7 +95,7 @@ func (jfc *JFCEndpoint) cipher(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write([]byte(d))
+	_, _ = w.Write([]byte(d))
 }
 
 // Field Decipher godoc
@@ -153,5 +153,5 @@ func (jfc *JFCEndpoint) decipher(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write([]byte(d))
+	_, _ = w.Write([]byte(d))
 }

--- a/internal/server/keyRingEndpoint.go
+++ b/internal/server/keyRingEndpoint.go
@@ -79,7 +79,7 @@ func (kre *KeyRingEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(key))
+	_, _ = w.Write([]byte(key))
 }
 
 // Get Cached Keys godoc
@@ -113,7 +113,7 @@ func (kre *KeyRingEndpoint) getCachedKeys(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Get Loaded Private Keys godoc
@@ -146,7 +146,7 @@ func (kre *KeyRingEndpoint) getLoadedPrivateKeys(w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Delete Private Key godoc
@@ -190,7 +190,7 @@ func (kre *KeyRingEndpoint) deletePrivateKey(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write(d)
+	_, _ = w.Write(d)
 }
 
 // Add Private Key godoc
@@ -268,5 +268,5 @@ func (kre *KeyRingEndpoint) addPrivateKey(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write(d)
+	_, _ = w.Write(d)
 }

--- a/internal/server/keyRingEndpoint.go
+++ b/internal/server/keyRingEndpoint.go
@@ -59,7 +59,6 @@ func (kre *KeyRingEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(kre.log, r)
 	ctx = wrapContextWithDatabaseHandler(kre.dbh, ctx)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -80,8 +79,7 @@ func (kre *KeyRingEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(key))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(key))
 }
 
 // Get Cached Keys godoc
@@ -96,7 +94,6 @@ func (kre *KeyRingEndpoint) getCachedKeys(w http.ResponseWriter, r *http.Request
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(kre.log, r)
 	ctx = wrapContextWithDatabaseHandler(kre.dbh, ctx)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -116,8 +113,7 @@ func (kre *KeyRingEndpoint) getCachedKeys(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Get Loaded Private Keys godoc
@@ -132,7 +128,6 @@ func (kre *KeyRingEndpoint) getLoadedPrivateKeys(w http.ResponseWriter, r *http.
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(kre.log, r)
 	ctx = wrapContextWithDatabaseHandler(kre.dbh, ctx)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -151,8 +146,7 @@ func (kre *KeyRingEndpoint) getLoadedPrivateKeys(w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Delete Private Key godoc
@@ -170,7 +164,6 @@ func (kre *KeyRingEndpoint) deletePrivateKey(w http.ResponseWriter, r *http.Requ
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(kre.dbh, ctx)
 	log := wrapLogWithRequestID(kre.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -197,8 +190,7 @@ func (kre *KeyRingEndpoint) deletePrivateKey(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write(d)
-	LogExit(log, r, 200, n)
+	w.Write(d)
 }
 
 // Add Private Key godoc
@@ -216,7 +208,6 @@ func (kre *KeyRingEndpoint) addPrivateKey(w http.ResponseWriter, r *http.Request
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(kre.dbh, ctx)
 	log := wrapLogWithRequestID(kre.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -277,6 +268,5 @@ func (kre *KeyRingEndpoint) addPrivateKey(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ = w.Write(d)
-	LogExit(log, r, 200, n)
+	w.Write(d)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,9 +5,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-
 	"github.com/gorilla/mux"
 	"github.com/quan-to/chevron/internal/agent"
 	"github.com/quan-to/chevron/internal/config"
@@ -18,6 +15,8 @@ import (
 	"github.com/quan-to/chevron/pkg/interfaces"
 	"github.com/quan-to/slog"
 	httpSwagger "github.com/swaggo/http-swagger"
+	"io/ioutil"
+	"net/http"
 )
 
 // @title Remote Signer API
@@ -93,6 +92,8 @@ func GenRemoteSignerServerMux(slog slog.Instance, sm interfaces.SecretsManager, 
 		r.PathPrefix("/swagger").HandlerFunc(httpSwagger.Handler())
 	}
 
+	r.Use(LoggingMiddleware)
+
 	// Add for /
 	AddHKPEndpoints(log, dbh, r.PathPrefix("/pks").Subrouter())
 	ge.AttachHandlers(r.PathPrefix("/gpg").Subrouter())
@@ -101,8 +102,8 @@ func GenRemoteSignerServerMux(slog slog.Instance, sm interfaces.SecretsManager, 
 	kre.AttachHandlers(r.PathPrefix("/keyRing").Subrouter())
 	sks.AttachHandlers(r.PathPrefix("/sks").Subrouter())
 	jfc.AttachHandlers(r.PathPrefix("/fieldCipher").Subrouter())
-
 	// Add for /remoteSigner
+
 	AddHKPEndpoints(log, dbh, r.PathPrefix("/remoteSigner/pks").Subrouter())
 	ge.AttachHandlers(r.PathPrefix("/remoteSigner/gpg").Subrouter())
 	ie.AttachHandlers(r.PathPrefix("/remoteSigner/__internal").Subrouter())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/quan-to/chevron/internal/agent"
 	"github.com/quan-to/chevron/internal/config"
@@ -15,8 +18,6 @@ import (
 	"github.com/quan-to/chevron/pkg/interfaces"
 	"github.com/quan-to/slog"
 	httpSwagger "github.com/swaggo/http-swagger"
-	"io/ioutil"
-	"net/http"
 )
 
 // @title Remote Signer API
@@ -94,16 +95,16 @@ func GenRemoteSignerServerMux(slog slog.Instance, sm interfaces.SecretsManager, 
 
 	r.Use(LoggingMiddleware)
 
-	AddHKPEndpoints(log, dbh, r.PathPrefix("/pks").Subrouter())
 	// Add for /
+	AddHKPEndpoints(log, dbh, r.PathPrefix("/pks").Subrouter())
 	ge.AttachHandlers(r.PathPrefix("/gpg").Subrouter())
 	ie.AttachHandlers(r.PathPrefix("/__internal").Subrouter())
 	te.AttachHandlers(r.PathPrefix("/tests").Subrouter())
 	kre.AttachHandlers(r.PathPrefix("/keyRing").Subrouter())
 	sks.AttachHandlers(r.PathPrefix("/sks").Subrouter())
 	jfc.AttachHandlers(r.PathPrefix("/fieldCipher").Subrouter())
-	// Add for /remoteSigner
 
+	// Add for /remoteSigner
 	AddHKPEndpoints(log, dbh, r.PathPrefix("/remoteSigner/pks").Subrouter())
 	ge.AttachHandlers(r.PathPrefix("/remoteSigner/gpg").Subrouter())
 	ie.AttachHandlers(r.PathPrefix("/remoteSigner/__internal").Subrouter())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,8 +94,8 @@ func GenRemoteSignerServerMux(slog slog.Instance, sm interfaces.SecretsManager, 
 
 	r.Use(LoggingMiddleware)
 
-	// Add for /
 	AddHKPEndpoints(log, dbh, r.PathPrefix("/pks").Subrouter())
+	// Add for /
 	ge.AttachHandlers(r.PathPrefix("/gpg").Subrouter())
 	ie.AttachHandlers(r.PathPrefix("/__internal").Subrouter())
 	te.AttachHandlers(r.PathPrefix("/tests").Subrouter())
@@ -125,7 +125,6 @@ func GenRemoteSignerServerMux(slog slog.Instance, sm interfaces.SecretsManager, 
 
 	// Catch All for unhandled endpoints
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		InitHTTPTimer(log, r)
 		CatchAllRouter(w, r, log)
 	})
 

--- a/internal/server/sksEndpoint.go
+++ b/internal/server/sksEndpoint.go
@@ -60,7 +60,6 @@ func (sks *SKSEndpoint) AttachHandlers(r *mux.Router) {
 // @Router /sks/getKey [get]
 func (sks *SKSEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
@@ -82,8 +81,7 @@ func (sks *SKSEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(key))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(key))
 }
 
 // Search GPG Key by Name godoc
@@ -99,7 +97,6 @@ func (sks *SKSEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 // @Router /sks/searchByName [get]
 func (sks *SKSEndpoint) searchByName(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
@@ -145,8 +142,7 @@ func (sks *SKSEndpoint) searchByName(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Search GPG Key by Fingerprint godoc
@@ -162,7 +158,6 @@ func (sks *SKSEndpoint) searchByName(w http.ResponseWriter, r *http.Request) {
 // @Router /sks/searchByFingerPrint [get]
 func (sks *SKSEndpoint) searchByFingerPrint(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
@@ -208,8 +203,7 @@ func (sks *SKSEndpoint) searchByFingerPrint(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Search GPG Key by Email godoc
@@ -225,7 +219,6 @@ func (sks *SKSEndpoint) searchByFingerPrint(w http.ResponseWriter, r *http.Reque
 // @Router /sks/searchByEmail [get]
 func (sks *SKSEndpoint) searchByEmail(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
@@ -271,8 +264,7 @@ func (sks *SKSEndpoint) searchByEmail(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Search GPG Key by Value godoc
@@ -288,7 +280,6 @@ func (sks *SKSEndpoint) searchByEmail(w http.ResponseWriter, r *http.Request) {
 // @Router /sks/search [get]
 func (sks *SKSEndpoint) search(w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx := wrapContextWithRequestID(r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
@@ -334,8 +325,7 @@ func (sks *SKSEndpoint) search(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	n, _ := w.Write(bodyData)
-	LogExit(log, r, 200, n)
+	w.Write(bodyData)
 }
 
 // Add Public Key godoc
@@ -351,7 +341,6 @@ func (sks *SKSEndpoint) search(w http.ResponseWriter, r *http.Request) {
 func (sks *SKSEndpoint) addKey(w http.ResponseWriter, r *http.Request) {
 	ctx := wrapContextWithRequestID(r)
 	log := wrapLogWithRequestID(sks.log, r)
-	InitHTTPTimer(log, r)
 	ctx = wrapContextWithDatabaseHandler(sks.dbh, ctx)
 
 	var data models.SKSAddKey
@@ -375,6 +364,5 @@ func (sks *SKSEndpoint) addKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte("OK"))
-	LogExit(log, r, 200, n)
+	w.Write([]byte("OK"))
 }

--- a/internal/server/sksEndpoint.go
+++ b/internal/server/sksEndpoint.go
@@ -81,7 +81,7 @@ func (sks *SKSEndpoint) getKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte(key))
+	_, _ = w.Write([]byte(key))
 }
 
 // Search GPG Key by Name godoc
@@ -142,7 +142,7 @@ func (sks *SKSEndpoint) searchByName(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Search GPG Key by Fingerprint godoc
@@ -203,7 +203,7 @@ func (sks *SKSEndpoint) searchByFingerPrint(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Search GPG Key by Email godoc
@@ -264,7 +264,7 @@ func (sks *SKSEndpoint) searchByEmail(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Search GPG Key by Value godoc
@@ -325,7 +325,7 @@ func (sks *SKSEndpoint) search(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeJSON)
 	w.WriteHeader(200)
-	w.Write(bodyData)
+	_, _ = w.Write(bodyData)
 }
 
 // Add Public Key godoc
@@ -364,5 +364,5 @@ func (sks *SKSEndpoint) addKey(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", models.MimeText)
 	w.WriteHeader(200)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }

--- a/internal/server/staticAgentGraphiql.go
+++ b/internal/server/staticAgentGraphiql.go
@@ -29,7 +29,6 @@ func MakeStaticGraphiQL(log slog.Instance) *StaticGraphiQL {
 
 func (gql *StaticGraphiQL) displayFile(filename string, w http.ResponseWriter, r *http.Request) {
 	log := wrapLogWithRequestID(gql.log, r)
-	InitHTTPTimer(log, r)
 
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -54,8 +53,7 @@ func (gql *StaticGraphiQL) displayFile(filename string, w http.ResponseWriter, r
 	}
 
 	w.WriteHeader(200)
-	n, _ := w.Write([]byte(fileData))
-	LogExit(log, r, 200, n)
+	w.Write([]byte(fileData))
 }
 
 func (gql *StaticGraphiQL) AttachHandlers(r *mux.Router) {

--- a/internal/server/staticAgentGraphiql.go
+++ b/internal/server/staticAgentGraphiql.go
@@ -53,7 +53,7 @@ func (gql *StaticGraphiQL) displayFile(filename string, w http.ResponseWriter, r
 	}
 
 	w.WriteHeader(200)
-	w.Write([]byte(fileData))
+	_, _ = w.Write([]byte(fileData))
 }
 
 func (gql *StaticGraphiQL) AttachHandlers(r *mux.Router) {


### PR DESCRIPTION
Closes #98 

## What
- add a log middleware
- add fields to structured log

## Why
- simplify the way that is logged the entry/exit requests
- make clear what is happening in the service

## How
- creating a middleware function
- setting mux to use the middleware
- setting slog with fields