### PR TITLE
[REFACTOR] | 98 - skip test endpoints from logging middleware

### DIFF
--- a/internal/server/httpmiddlewares.go
+++ b/internal/server/httpmiddlewares.go
@@ -9,6 +9,11 @@ import (
 	"github.com/quan-to/slog"
 )
 
+// skipEndpoints represents the endpoints that must be skipped in LoggingMiddleware
+var skipEndpoints = map[string]bool{
+	"/test/ping": true,
+}
+
 // ResponseWriter is a http.ResponseWriter wrapper that provides the status code and content length info.
 type ResponseWriter struct {
 	http.ResponseWriter
@@ -37,6 +42,11 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 	log := slog.Scope("LoggingMiddleware")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if skipEndpoints[r.URL.Path] {
+			next.ServeHTTP(w, r)
+			return
+		}
 
 		startTime := time.Now()
 		host, _, _ := net.SplitHostPort(r.RemoteAddr)

--- a/internal/server/httpmiddlewares_test.go
+++ b/internal/server/httpmiddlewares_test.go
@@ -102,3 +102,25 @@ func TestLoggingMiddleware(t *testing.T) {
 	slog.SetTestMode()
 	slog.SetLogFormat(slog.PIPE)
 }
+
+func TestSkipEndpointLoggingMiddleware(t *testing.T) {
+	var logBuffer bytes.Buffer
+	slog.UnsetTestMode()
+	slog.SetDefaultOutput(&logBuffer)
+	slog.SetLogFormat(slog.JSON)
+
+	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { })
+
+	for endpoint := range skipEndpoints {
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://huehuebr.com%s", endpoint), nil)
+
+		LoggingMiddleware(mockHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+		if logBuffer.Len() != 0 {
+			t.Fatalf("Got %s; want an empty log from endpoint %s", logBuffer.String(), endpoint)
+		}
+	}
+
+	slog.SetTestMode()
+	slog.SetLogFormat(slog.PIPE)
+}


### PR DESCRIPTION
Related to #98 

## What
- Skip test endpoint from logging middleware

## Why
- The logging middleware is generating a lot of logs to endpoint /test/ping, it is polluting the log visualization.

## How
- creating a list of endpoints to be skipped