### PR TITLE
fix(middleware): typo on skip endpoint

### DIFF
--- a/internal/server/httpmiddlewares.go
+++ b/internal/server/httpmiddlewares.go
@@ -11,7 +11,7 @@ import (
 
 // skipEndpoints represents the endpoints that must be skipped in LoggingMiddleware
 var skipEndpoints = map[string]bool{
-	"/test/ping": true,
+	"/tests/ping": true,
 }
 
 // ResponseWriter is a http.ResponseWriter wrapper that provides the status code and content length info.


### PR DESCRIPTION
Related to #98 

## What
- fix the endpoint name to be skipped

## Why
- the endpoint /tests/ping must be skipped on logging middleware

## How
- fixing the name of endpoint in skipEndpoint map