### PR TITLE
hotfix(travis-ci): remove compile support for arch 386

### DIFF
--- a/scripts/travis-binary-build.sh
+++ b/scripts/travis-binary-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BUILD_LINUX_ARCH="arm arm64 386 amd64"
-BUILD_OTHER_ARCH="386 amd64"
+BUILD_OTHER_ARCH="amd64"
 BUILD_OS="windows freebsd darwin openbsd"
 
 export GOCACHE=/tmp/gocache


### PR DESCRIPTION
Closes #103 

## What
- Travis script is breaking on cross compilation

## Why
- darwin/386 is no longer supported as of go 1.14 (https://golang.org/doc/go1.14#darwin)

## How
- remove arch 386 from the list of archs to be compiled

## Notes
- we are assuming that nobody is using this old arch. 
- The binary for linux/386 will continue to generate.